### PR TITLE
fix(core): opentelemetry-http-interceptor should accept pathname

### DIFF
--- a/projects/opentelemetry-interceptor/src/lib/interceptor/opentelemetry-http.interceptor.spec.ts
+++ b/projects/opentelemetry-interceptor/src/lib/interceptor/opentelemetry-http.interceptor.spec.ts
@@ -49,6 +49,15 @@ describe('OpenTelemetryHttpInterceptor', () => {
     httpControllerMock.verify();
   });
 
+  it('Should accept pathname', () => {
+    const url = '/api/v1/test?key=value';
+    httpClient.get(url).subscribe();
+    const req = httpControllerMock.expectOne(url);
+    expect(req.request.url).not.toBeNull();
+    req.flush({});
+    httpControllerMock.verify();
+  });
+
   it('verify with production mode', () => {
     ({ httpClient, httpControllerMock } = defineModuleTest(
       httpClient,


### PR DESCRIPTION
Currently, opentelemetry-http.interceptor accepts only URL with hostname and  pathname. This intercetpor should also accept one pathname. It's a classic usecase with the browser platform. Thus, this feature works only with the Brower Platform. Otherwise, we have the specify the whole URL.