### PR TITLE
feat: add config to ignore urls in interceptor

### DIFF
--- a/projects/opentelemetry-interceptor/__mocks__/data/config.mock.ts
+++ b/projects/opentelemetry-interceptor/__mocks__/data/config.mock.ts
@@ -223,4 +223,15 @@ export const instrumentationProductionOtelConfig: OpenTelemetryConfig = {
   }
 };
 
-
+/**
+ * @ignore
+ */
+ export const otelTraceparentIgnoreUrlsConfig: OpenTelemetryConfig = {
+  commonConfig: {
+    serviceName: 'test',
+    logBody: true
+  },
+  ignoreUrls: {
+    urls: ['http://url.test.com']
+  }
+};

--- a/projects/opentelemetry-interceptor/src/lib/configuration/opentelemetry-config.ts
+++ b/projects/opentelemetry-interceptor/src/lib/configuration/opentelemetry-config.ts
@@ -94,6 +94,19 @@ export interface B3PropagatorConfig {
    */
   multiHeader?: string;
 }
+
+/**
+ * Configuration for IgnoreUrlsConfig
+ */
+ export interface IgnoreUrlsConfig {
+  /**
+   * URLs that partially match any regex in ignoreUrls will not be traced.
+   * In addition, URLs that are _exact matches_ of strings in ignoreUrls will
+   * also not be traced.
+   */
+  urls?: Array<string | RegExp>;
+}
+
 /**
  * OpenTelemetryConfig
  */
@@ -110,6 +123,8 @@ export interface OpenTelemetryConfig {
   jaegerPropagatorConfig?: JaegerPropagatorConfig;
   /** b3PropagatorConfig */
   b3PropagatorConfig?: B3PropagatorConfig;
+  /** ignoreUrls */
+  ignoreUrls?: IgnoreUrlsConfig;
 }
 
 /** OTEL_CONFIG : Config injection */

--- a/projects/opentelemetry-interceptor/src/lib/interceptor/opentelemetry-http.interceptor.spec.ts
+++ b/projects/opentelemetry-interceptor/src/lib/interceptor/opentelemetry-http.interceptor.spec.ts
@@ -24,6 +24,7 @@ import {
   otelcolExporterWithProbabilitySamplerAtTwoConfig,
   otelcolExporterProductionConfig,
   otelcolExporterProductionAndBatchSpanProcessorConfig,
+  otelTraceparentIgnoreUrlsConfig,
 } from '../../../__mocks__/data/config.mock';
 import { of } from 'rxjs';
 import { ConsoleSpanExporterModule } from '../services/exporter/console/console-span-exporter.module';
@@ -125,6 +126,21 @@ describe('OpenTelemetryHttpInterceptor', () => {
       url: url + '/test?myCallback=JSONP_CALLBACK',
     });
     expect(req.request.headers.get('traceparent')).not.toBeNull();
+    req.flush({});
+    httpControllerMock.verify();
+  });
+
+  it('Exclude traceparent header on a given request that is included in the ignoreUrls array', () => {
+    ({ httpClient, httpControllerMock } = defineModuleTest(
+      httpClient,
+      httpControllerMock,
+      otelTraceparentIgnoreUrlsConfig
+    ));
+    const url = 'http://url.test.com';
+    httpClient.get(url).subscribe();
+    const req = httpControllerMock.expectOne(url);
+    expect(req.request.headers).not.toBeNull();
+    expect(req.request.headers.get('traceparent')).toBeNull();
     req.flush({});
     httpControllerMock.verify();
   });

--- a/projects/opentelemetry-interceptor/src/lib/interceptor/opentelemetry-http.interceptor.ts
+++ b/projects/opentelemetry-interceptor/src/lib/interceptor/opentelemetry-http.interceptor.ts
@@ -24,6 +24,7 @@ import {
   AlwaysOffSampler,
   TraceIdRatioBasedSampler,
   ParentBasedSampler,
+  isUrlIgnored
 } from '@opentelemetry/core';
 import { SemanticResourceAttributes, SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { Resource } from '@opentelemetry/resources';
@@ -109,7 +110,7 @@ export class OpenTelemetryHttpInterceptor implements HttpInterceptor {
     request: HttpRequest<unknown>,
     next: HttpHandler
   ): Observable<HttpEvent<unknown>> {
-    if (this.isUrlIgnored(request.url, this.config.ignoreUrls?.urls)) {
+    if (isUrlIgnored(request.url, this.config.ignoreUrls?.urls)) {
       return next.handle(request);
     }
     this.contextManager.disable(); //FIX - reinit contextManager for each http call
@@ -154,32 +155,6 @@ export class OpenTelemetryHttpInterceptor implements HttpInterceptor {
         this.contextManager.disable();
       })
     );
-  }
-
-  /**
-   * Check if {@param url} should be ignored when comparing against {@param ignoredUrls}
-   *
-   * @param ignoredUrls
-   * @param url
-   */
-  private isUrlIgnored(url, ignoredUrls) {
-    if (!ignoredUrls) {
-      return false;
-    }
-    for (const ignoreUrl of ignoredUrls) {
-      if (this.urlMatches(url, ignoreUrl)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private urlMatches(url, urlToMatch) {
-    if (typeof urlToMatch === 'string') {
-      return url === urlToMatch;
-    } else {
-      return !!url.match(urlToMatch);
-    }
   }
 
   /**


### PR DESCRIPTION
Added configuration to ignoreUrls.
Modified the interceptor to check if the url is included inside the ignoreUrls array, otherwise it follows the normal path.

Based on the [XMLHttpRequestInstrumentation](https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-xml-http-request) ignoreUrl.