### PR TITLE
Export IgnoreUrlsConfig from public-api.ts

### DIFF
--- a/projects/opentelemetry-interceptor/src/public-api.ts
+++ b/projects/opentelemetry-interceptor/src/public-api.ts
@@ -34,6 +34,7 @@ export {
   ZipkinCollectorConfig,
   JaegerPropagatorConfig,
   B3PropagatorConfig,
+  IgnoreUrlsConfig,
   OTEL_LOGGER,
   OTEL_CUSTOM_SPAN,
   OTEL_INSTRUMENTATION_PLUGINS


### PR DESCRIPTION
It is part of `OpenTelemetryConfig` and should also be publicly available. Currently `IgnoreUrlsConfig` needs to be imported as

```typescript
import { IgnoreUrlsConfig } from "@jufab/opentelemetry-angular-interceptor/lib/configuration/opentelemetry-config";
```

instead of

```typescript
import { IgnoreUrlsConfig } from "@jufab/opentelemetry-angular-interceptor/public-api";
```
