### PR TITLE
Exposing OpenTelemetryHttpInterceptor for custom usage.

### DIFF
--- a/projects/opentelemetry-interceptor/src/public-api.ts
+++ b/projects/opentelemetry-interceptor/src/public-api.ts
@@ -3,6 +3,7 @@
  */
 // Interceptor
 export { OpenTelemetryInterceptorModule } from './lib/opentelemetry-interceptor.module';
+export { OpenTelemetryHttpInterceptor } from './lib/interceptor/opentelemetry-http.interceptor';
 // Exporter
 export { OtelColExporterModule } from './lib/services/exporter/otelcol/otelcol-exporter.module';
 export { ConsoleSpanExporterModule } from './lib/services/exporter/console/console-span-exporter.module';


### PR DESCRIPTION
Hello!

We have a use-case that requires direct usage of the OpenTelemetryHttpInterceptor class but it is not currently exposed via the `public-api.ts`.

In a nutshell, we have to fetch remote configurations using the `HttpClient` but we encounter DI exceptions unless we delay the provider.  We have a tentative solution but it requires the creation of a OpenTelemetryHttpInterceptor instance directly.