### PR TITLE
Fix imports from build/src

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -44,10 +44,6 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
-            "allowedCommonJsDependencies": [
-              "@opentelemetry/exporter-trace-otlp-http",
-              "os"
-            ],
             "outputPath": "dist/interceptor-example",
             "index": "projects/interceptor-example/src/index.html",
             "main": "projects/interceptor-example/src/main.ts",

--- a/projects/opentelemetry-interceptor/src/lib/services/exporter/otelcol/otelcol-exporter.service.spec.ts
+++ b/projects/opentelemetry-interceptor/src/lib/services/exporter/otelcol/otelcol-exporter.service.spec.ts
@@ -6,7 +6,7 @@ import {
   otelcolExporterConfig,
   otelcolExporterWithoutUrlAndB3Config,
 } from '../../../../../__mocks__/data/config.mock';
-import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http/build/src/platform/browser/OTLPTraceExporter';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 
 
 describe('OtelcolExporterService', () => {

--- a/projects/opentelemetry-interceptor/src/lib/services/exporter/otelcol/otelcol-exporter.service.ts
+++ b/projects/opentelemetry-interceptor/src/lib/services/exporter/otelcol/otelcol-exporter.service.ts
@@ -5,7 +5,7 @@ import {
   OpenTelemetryConfig,
   OTEL_CONFIG
 } from '../../../configuration/opentelemetry-config';
-import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http/build/src/platform/browser/OTLPTraceExporter';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { OTLPExporterConfigBase } from '@opentelemetry/otlp-exporter-base';
 
 /**

--- a/projects/opentelemetry-interceptor/src/lib/services/propagator/noop-http-text-propagator/noop-text-map-propagator.service.spec.ts
+++ b/projects/opentelemetry-interceptor/src/lib/services/propagator/noop-http-text-propagator/noop-text-map-propagator.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { NoopTextMapPropagatorService } from './noop-text-map-propagator.service';
-import { NoopTextMapPropagator } from '@opentelemetry/api/build/src/propagation/NoopTextMapPropagator';
+import { NoopTextMapPropagator } from '@opentelemetry/api/build/esm/propagation/NoopTextMapPropagator';
 
 describe('NoopTextMapPropagatorService', () => {
   let service: NoopTextMapPropagatorService;

--- a/projects/opentelemetry-interceptor/src/lib/services/propagator/noop-http-text-propagator/noop-text-map-propagator.service.spec.ts
+++ b/projects/opentelemetry-interceptor/src/lib/services/propagator/noop-http-text-propagator/noop-text-map-propagator.service.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
 import { NoopTextMapPropagatorService } from './noop-text-map-propagator.service';
-import { NoopTextMapPropagator } from '@opentelemetry/api/build/esm/propagation/NoopTextMapPropagator';
 
 describe('NoopTextMapPropagatorService', () => {
   let service: NoopTextMapPropagatorService;
@@ -12,7 +11,7 @@ describe('NoopTextMapPropagatorService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
-    expect(service.getPropagator()).toBeInstanceOf(NoopTextMapPropagator);
+    expect(service.getPropagator()).toBeNull();
   });
 });
 

--- a/projects/opentelemetry-interceptor/src/lib/services/propagator/noop-http-text-propagator/noop-text-map-propagator.service.ts
+++ b/projects/opentelemetry-interceptor/src/lib/services/propagator/noop-http-text-propagator/noop-text-map-propagator.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { IPropagator } from '../propagator.interface';
 import { TextMapPropagator } from '@opentelemetry/api';
-import { NoopTextMapPropagator } from '@opentelemetry/api/build/src/propagation/NoopTextMapPropagator';
+import { NoopTextMapPropagator } from '@opentelemetry/api/build/esm/propagation/NoopTextMapPropagator';
 /**
  * NoopHttpTextPropagatorService
  */

--- a/projects/opentelemetry-interceptor/src/lib/services/propagator/noop-http-text-propagator/noop-text-map-propagator.service.ts
+++ b/projects/opentelemetry-interceptor/src/lib/services/propagator/noop-http-text-propagator/noop-text-map-propagator.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import { IPropagator } from '../propagator.interface';
 import { TextMapPropagator } from '@opentelemetry/api';
-import { NoopTextMapPropagator } from '@opentelemetry/api/build/esm/propagation/NoopTextMapPropagator';
 /**
  * NoopHttpTextPropagatorService
  */
@@ -12,10 +11,10 @@ export class NoopTextMapPropagatorService implements IPropagator {
   /**
    * Return an NoopTextMapPropagator
    *
-   * @return TextMapPropagator as NoopTextMapPropagator
+   * @return TextMapPropagator as null
    */
   getPropagator(): TextMapPropagator {
-    return new NoopTextMapPropagator();
+    return null;
   }
 }
 


### PR DESCRIPTION
These imports directly import the CommonJS version instead of selecting via the package definition.

In angular these produce warnings about CommonJS packages.