### PR TITLE
Include the url path in the exported span name

### DIFF
--- a/cypress/e2e/post-backend.cy.ts
+++ b/cypress/e2e/post-backend.cy.ts
@@ -12,7 +12,7 @@ describe('Post Page', () => {
     cy.get('i').contains('result call : test').should(() => {
       const value = JSON.parse(localStorage.getItem('consoleDir'));
       expect(value.traceId).to.be.not.undefined;
-      expect(value.name).to.eq('POST');
+      expect(value.name).to.eq('POST /api/');
     });
   });
 });

--- a/cypress/e2e/view-backend.cy.ts
+++ b/cypress/e2e/view-backend.cy.ts
@@ -10,7 +10,7 @@ describe('View Page', () => {
     cy.get('i').should(() => {
       const value = JSON.parse(localStorage.getItem('consoleDir'));
       expect(value.traceId).to.be.not.undefined;
-      expect(value.name).to.eq('GET');
+      expect(value.name).to.eq('GET /api/');
     });
   });
 });

--- a/projects/opentelemetry-interceptor/src/lib/interceptor/opentelemetry-http.interceptor.ts
+++ b/projects/opentelemetry-interceptor/src/lib/interceptor/opentelemetry-http.interceptor.ts
@@ -198,7 +198,7 @@ export class OpenTelemetryHttpInterceptor implements HttpInterceptor {
     const span = this.tracer
       .getTracer(infoLibrary.name, infoLibrary.version)
       .startSpan(
-        `${request.method.toUpperCase()}`,
+        `${request.method.toUpperCase()} ${new URL(request.url).pathname}`,
         {
           attributes: {
             [SEMATTRS_HTTP_METHOD]: request.method,


### PR DESCRIPTION
This PR changes the span name attribute to include the path of the request. The span name would for instance change from `GET` to `GET /api/some/path`.
This would be useful for the Jaeger ui, where the span name is one of the primary attributes that is displayed there (sorry for the bad image quality):
<img src="https://github.com/user-attachments/assets/c1d1bd36-bc16-4a13-a45d-4d165a04c2b4" width="400" />

The red box in the image would then contain more meaningful text, that would allow to identify the path immediately, without expanding the corresponding bar and looking for other attributes.

@jufab Can you review?

Fixes #207